### PR TITLE
Add docstrings for utilities

### DIFF
--- a/utility/cvat_annot_processing.py
+++ b/utility/cvat_annot_processing.py
@@ -12,16 +12,20 @@ logger = logging.getLogger(__name__)
 
 
 def mv_annot_img_and_label(
-    prefix: str, img_file: str, label_file: str, dest_img_dir: str, dest_label_dir: str
+    prefix: str,
+    img_file: str,
+    label_file: str,
+    dest_img_dir: str,
+    dest_label_dir: str,
 ) -> None:
-    """Move image and label file
+    """Move image and label files to target directories.
 
     Args:
-        prefix (str):
-        img_file (str):
-        label_file (str):
-        dest_img_dir (str):
-        dest_label_dir (str):
+        prefix (str): Prefix to apply to the destination file names.
+        img_file (str): Path to the source image file.
+        label_file (str): Path to the source label file.
+        dest_img_dir (str): Directory to copy the image into.
+        dest_label_dir (str): Directory to copy the label into.
     """
     new_label_file = os.path.basename(label_file).replace("frame", prefix)
     new_img_file = os.path.basename(img_file).replace("frame", prefix)
@@ -30,10 +34,10 @@ def mv_annot_img_and_label(
 
 
 def cleanup_no_label_img(basedir: str) -> None:
-    """Remove frame with no object in it
+    """Remove frames that contain no annotation.
 
     Args:
-        basedir (str):
+        basedir (str): Directory containing frame image and label files.
     """
     for label_file in sorted(glob.glob(os.path.join(basedir, "frame_*.txt"))):
         img_file = label_file.replace(".txt", ".PNG")
@@ -55,8 +59,20 @@ class CVATAnnot:
     max_image_count: int = -1  # -1 for all image
 
     def __init__(
-        self, video_name, annot_dir, downsample_percent=1, max_image_count=None
-    ):
+        self,
+        video_name: str,
+        annot_dir: str,
+        downsample_percent: float = 1,
+        max_image_count: int | None = None,
+    ) -> None:
+        """Initialize CVAT annotation handler.
+
+        Args:
+            video_name (str): Name of the source video.
+            annot_dir (str): Directory containing annotation files.
+            downsample_percent (float, optional): Portion of images to keep. Defaults to 1.
+            max_image_count (int | None, optional): Maximum number of images to output. Defaults to None.
+        """
         self.video_name = video_name
         self.annot_dir = annot_dir
         total_img_cnt = len(os.listdir(annot_dir)) // 2
@@ -67,10 +83,10 @@ class CVATAnnot:
             self.downsample_percent = downsample_percent
 
     def output_fltrd_data(self, outdir: str) -> None:
-        """Output filtered data
+        """Output filtered annotation images and labels.
 
         Args:
-            outdir (str):
+            outdir (str): Root directory where train/ folders will be created.
         """
         dest_img_dir = os.path.join(outdir, "train/images/shrimp/")
         dest_label_dir = os.path.join(outdir, "train/labels/shrimp/")

--- a/utility/pi_camera/ws281x_led_control.py
+++ b/utility/pi_camera/ws281x_led_control.py
@@ -97,6 +97,14 @@ def strobe_effect(strip, delay_time, led_array=None):
 
 
 def parse_led_config(led_config: str) -> list:
+    """Parse LED configuration string into index-color pairs.
+
+    Args:
+        led_config (str): Configuration string (e.g., "0-5:255:0:0").
+
+    Returns:
+        list: A list of [index, Color] entries.
+    """
     led_config_list = led_config.split(",")
     idx_and_color = []
     for elem in led_config_list:

--- a/utility/video_processing.py
+++ b/utility/video_processing.py
@@ -13,10 +13,10 @@ def sample_video(
     """Sample input video and generate images from it.
 
     Args:
-        video_file (str):
-        output_img_dir (str):
-        img_number (int, optional): Number of images to create. Defaults to -1 for all frames.
-        sampling_level (int, optional): How frequently sample the video. Defaults to 10.
+        video_file (str): Path to the source video file.
+        output_img_dir (str): Directory where the sampled frames will be saved.
+        img_number (int, optional): Number of images to create. Defaults to ``-1`` for all frames.
+        crop (list[int] | None, optional): ``[x, y, width, height]`` crop region. Defaults to ``None``.
     """
     basename = os.path.basename(video_file).rsplit(".", 1)[0]
     idx = 0
@@ -51,7 +51,13 @@ def sample_video(
     cap.release()
 
 
-def play_video(video_input, annotation):
+def play_video(video_input: str, annotation: str) -> None:
+    """Play a video and overlay bounding box annotations.
+
+    Args:
+        video_input (str): Path to the input video file.
+        annotation (str): Path to the annotation file.
+    """
     print(f"Showing image annotation {annotation}")
     annotation_df = pd.read_csv(annotation, sep="\t", header=None, dtype=float)
     cap = cv.VideoCapture(video_input)


### PR DESCRIPTION
## Summary
- clarify CVAT annotation helpers with typed parameters and descriptions
- type and document image prediction utilities for bounding box extraction and speed analysis
- document video sampling helper with explicit crop parameter

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896075b26408322bafaaaf765e1b97c